### PR TITLE
enable sqlite3 memory management

### DIFF
--- a/SonarExternal.cmake
+++ b/SonarExternal.cmake
@@ -561,8 +561,15 @@ function(build_sqlite3)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/sqlite3.cmake
     "cmake_minimum_required(VERSION 3.8)\n"
     "project(sqlite LANGUAGES C)\n"
+
     "add_library(sqlite3 sqlite3.c)\n"
-    "target_compile_definitions(sqlite3 PRIVATE SQLITE_ENABLE_FTS5 SQLITE_ENABLE_RTREE)\n"
+
+    "target_compile_definitions(sqlite3 PRIVATE\n"
+    "  SQLITE_ENABLE_FTS5\n"
+    "  SQLITE_ENABLE_RTREE\n"
+    "  SQLITE_ENABLE_MEMORY_MANAGEMENT\n"
+    ")\n"
+
     "install(TARGETS sqlite3 DESTINATION lib)\n"
     "install(FILES sqlite3.h sqlite3ext.h DESTINATION include)\n")
   message(STATUS "Building sqlite3 from ${SQLITE3_URL}")


### PR DESCRIPTION
The attempt to free SQLite memory [here](https://github.com/jsonar/sonarw/blob/f460c7409bd34c49488efbe352091e391f2e2a20/BackStore/SonarServer/sonardb_main.cc#L254-L255) is a [no-op](https://www.sqlite.org/c3ref/release_memory.html) because this API function is compiled as a no-op when `SQLITE_ENABLE_MEMORY_MANAGEMENT` is not defined.