### PR TITLE
Add with-tls flag to openldap build

### DIFF
--- a/SonarExternal.cmake
+++ b/SonarExternal.cmake
@@ -2348,7 +2348,7 @@ function(build_openldap)
     CONFIGURE_COMMAND <SOURCE_DIR>/configure
       CC=${CMAKE_C_COMPILER_LAUNCHER}\ ${CMAKE_C_COMPILER}
       CPPFLAGS=-isystem${openssl_install_dir}/include\ -isystem${sasl_install_dir}/include\ -isystem${krb5_install_dir}/include
-      LDFLAGS=-L${openssl_install_dir}/lib\ -lssl\ -lcrypto\ -L${sasl_install_dir}/lib\ -L${krb5_install_dir}/lib\ -lpthread
+      LDFLAGS=-L${openssl_install_dir}/lib\ -lssl\ -lcrypto\ -L${sasl_install_dir}/lib\ -L${krb5_install_dir}/lib\ -pthread
       --prefix <INSTALL_DIR>
       --with-tls=openssl
     BUILD_BYPRODUCTS

--- a/SonarExternal.cmake
+++ b/SonarExternal.cmake
@@ -2350,6 +2350,7 @@ function(build_openldap)
       CPPFLAGS=-isystem${openssl_install_dir}/include\ -isystem${sasl_install_dir}/include\ -isystem${krb5_install_dir}/include
       LDFLAGS=-L${openssl_install_dir}/lib\ -lssl\ -lcrypto\ -L${sasl_install_dir}/lib\ -L${krb5_install_dir}/lib\ -lpthread
       --prefix <INSTALL_DIR>
+      --with-tls=openssl
     BUILD_BYPRODUCTS
       <INSTALL_DIR>/lib/libldap.a
       <INSTALL_DIR>/lib/liblber.a


### PR DESCRIPTION
Sonarw was not compiling on the orchestrator machines. It was trying to use the tls lib in the system, in this case `gnu-tls`.
With the `with-tls` flag we can force openldap to use `openssl`.