### PR TITLE
Add flag enable-slapd to openldap configuration

### DIFF
--- a/SonarExternal.cmake
+++ b/SonarExternal.cmake
@@ -2350,6 +2350,7 @@ function(build_openldap)
       CPPFLAGS=-isystem${openssl_install_dir}/include\ -isystem${sasl_install_dir}/include\ -isystem${krb5_install_dir}/include
       LDFLAGS=-L${openssl_install_dir}/lib\ -lssl\ -lcrypto\ -L${sasl_install_dir}/lib\ -L${krb5_install_dir}/lib\ -pthread
       --prefix <INSTALL_DIR>
+      --enable-slapd=no
       --with-tls=openssl
     BUILD_BYPRODUCTS
       <INSTALL_DIR>/lib/libldap.a


### PR DESCRIPTION
@michaelJSonar  got a build failure on his machine.
```
checking db.h usability... no
checking db.h presence... no
checking for db.h... no
configure: error: BDB/HDB: BerkeleyDB not available
ninja: build stopped: subcommand failed.
```
Berkeley DB is used in `slapd` and we don't use it as it is only for setting up openldap servers. We only care for the client side for now.