### PR TITLE
Build different versions of ICU into different folders

### DIFF
--- a/SonarExternal.cmake
+++ b/SonarExternal.cmake
@@ -160,6 +160,7 @@ function(build_icu)
   string(REPLACE "." "_" ICU_VERSION_UNDERSCORE ${ICU_VERSION})
   string(REPLACE "." "-" ICU_VERSION_DASH ${ICU_VERSION})
   ExternalProject_Add(icu
+    PREFIX "icu-${ICU_VERSION}"
     URL https://github.com/unicode-org/icu/releases/download/release-${ICU_VERSION_DASH}/icu4c-${ICU_VERSION_UNDERSCORE}-src.tgz
     DOWNLOAD_NO_PROGRESS 1
     CONFIGURE_COMMAND <SOURCE_DIR>/source/configure


### PR DESCRIPTION
Relevant issue: jsonar/sonarw#6914

This change results in ICU being built into e.g. `frontend/icu-67.1` instead of `frontend/icu-prefix`. If we change the version we pass to `build_icu`, it should use an entirely separate folder, which should fix any issues with linking to the wrong ICU.

I tried just using a hardcoded ICU version and letting `ExternalProject` sort everything out, but I got an incremental build error when I tried that, and I don't know how to fix it.

This solution is simple and should work for us for now, and we can come back to figure out how to share the build folder if desired later.

There will be a companion fix in our `develop` branch to remove the ICU version from the CMake cache, since that's the first version that uses a different ICU.