### PR TITLE
update url for boost from bintray to jfrog

### DIFF
--- a/SonarExternal.cmake
+++ b/SonarExternal.cmake
@@ -1544,7 +1544,7 @@ function(build_boost)
     set(download_step SOURCE_DIR ${BOOST_SOURCE_DIR})
   else()
     set(download_step URL
-      https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORES}.tar.bz2
+      https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORES}.tar.bz2
       https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_UNDERSCORES}.tar.bz2/download)
   endif()
   foreach(component ${BOOST_COMPONENTS})


### PR DESCRIPTION
I did a quick check around, and I don't think we are using this url anywhere else.